### PR TITLE
Update cache_handler.php

### DIFF
--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -14,7 +14,7 @@
 
 if (!defined('e107_INIT')) { exit; }
 
-define('CACHE_PREFIX','<?php exit;');
+define('CACHE_PREFIX','<?php exit; ?>');
 
 /**
  * Class to cache data as files, improving site speed and throughput.
@@ -32,7 +32,7 @@ class ecache {
 	public $UserCacheActive;			// Checkable flag - TRUE if user cache enabled
 	public $SystemCacheActive;			// Checkable flag - TRUE if system cache enabled
 
-	const CACHE_PREFIX = '<?php exit;';
+	const CACHE_PREFIX = '<?php exit; ?>';
 
 	function __construct()
 	{


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your GitHub pull request. -->

<!--- Provide a general summary of your changes in the title section above. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/e107inc/e107/issues/4292#issue-767746587

### Description
<!--- Describe your changes in detail. -->
adding closing syntax to CACHE_PREFIX to prevent syntax errors in IDE

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.